### PR TITLE
fix: keystore file path to .parity

### DIFF
--- a/internal/core/services/ethereum_reward_client.go
+++ b/internal/core/services/ethereum_reward_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"os"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -49,7 +51,16 @@ func (c *EthereumRewardClient) DistributeRewards(result *models.TaskResult) erro
 		return c.distributeWithMockWallet(log, result)
 	}
 
-	ks, err := keystore.NewKeystore(keystore.Config{})
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get home directory")
+		return fmt.Errorf("home directory error: %w", err)
+	}
+
+	ks, err := keystore.NewKeystore(keystore.Config{
+		DirPath:  filepath.Join(homeDir, ".parity"),
+		FileName: "keystore.json",
+	})
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create keystore")
 	}
@@ -160,7 +171,7 @@ func (c *EthereumRewardClient) DistributeRewards(result *models.TaskResult) erro
 // distributeWithMockWallet handles reward distribution using a mock wallet for testing
 func (c *EthereumRewardClient) distributeWithMockWallet(log zerolog.Logger, result *models.TaskResult) error {
 	stakeInfo, err := c.stakeWallet.GetStakeInfo(result.DeviceID)
-	if err != nil {
+	if (err != nil) {
 		log.Error().Err(err).Msg("Stake info check failed")
 		return nil
 	}

--- a/internal/core/services/ethereum_reward_client.go
+++ b/internal/core/services/ethereum_reward_client.go
@@ -19,6 +19,11 @@ import (
 	"github.com/theblitlabs/parity-server/internal/core/ports"
 )
 
+const (
+	KeystoreDirName  = ".parity"
+	KeystoreFileName = "keystore.json"
+)
+
 type EthereumRewardClient struct {
 	cfg         *config.Config
 	stakeWallet ports.StakeWallet
@@ -58,8 +63,8 @@ func (c *EthereumRewardClient) DistributeRewards(result *models.TaskResult) erro
 	}
 
 	ks, err := keystore.NewKeystore(keystore.Config{
-		DirPath:  filepath.Join(homeDir, ".parity"),
-		FileName: "keystore.json",
+		DirPath:  filepath.Join(homeDir, KeystoreDirName),
+		FileName: KeystoreFileName,
 	})
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create keystore")
@@ -171,7 +176,7 @@ func (c *EthereumRewardClient) DistributeRewards(result *models.TaskResult) erro
 // distributeWithMockWallet handles reward distribution using a mock wallet for testing
 func (c *EthereumRewardClient) distributeWithMockWallet(log zerolog.Logger, result *models.TaskResult) error {
 	stakeInfo, err := c.stakeWallet.GetStakeInfo(result.DeviceID)
-	if (err != nil) {
+	if err != nil {
 		log.Error().Err(err).Msg("Stake info check failed")
 		return nil
 	}


### PR DESCRIPTION
# Fix: Keystore File Path to `.parity`

## Description

This PR fixes an issue where the system was incorrectly searching for the keystore file in `/root/.keystore/keystore.json` instead of the `.parity` directory. Now, the keystore file is correctly placed in `~/.parity/keystore.json`.

## Issue Reference

Closes: #18 

### Previous Behavior

- The system attempted to find the keystore file in `.keystore`, leading to authentication failures.
- Reward distribution functionality was affected due to the incorrect keystore path.

### Fix Implementation

- The home directory is now dynamically retrieved to ensure compatibility across environments.
- The keystore file is stored in `~/.parity/keystore.json`, aligning with the expected configuration.

## Expected Behavior

- The system correctly locates the keystore file in `.parity`.
- Reward distribution functions as expected.

## Testing

- Verified that the keystore is created in the correct `.parity` directory.
- Confirmed that reward distribution runs without authentication errors.

## Additional Notes

This fix improves system reliability by ensuring the keystore path is correctly set and dynamically adaptable across different environments.

---
