### PR TITLE
chore: remove unnecessary submodule checkout from code quality workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,9 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          token: ${{ secrets.PAT_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Set up Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
Simplifies the GitHub Actions checkout configuration by removing unnecessary token settings that was causing [CI failures](https://github.com/theblitlabs/parity-server/pull/22/checks#step:2:14). This change streamlines our workflow to use default checkout behavior which is sufficient for our linting needs, while fixing the "Input required and not supplied: token" error.