### PR TITLE
feat(task): make command parameter optional when creating tasks

### DIFF
--- a/internal/api/handlers/task_handler.go
+++ b/internal/api/handlers/task_handler.go
@@ -13,16 +13,16 @@ import (
 	"github.com/google/uuid"
 	walletsdk "github.com/theblitlabs/go-wallet-sdk"
 	"github.com/theblitlabs/gologger"
+	requestmodels "github.com/theblitlabs/parity-server/internal/api/models"
 	"github.com/theblitlabs/parity-server/internal/core/models"
 	"github.com/theblitlabs/parity-server/internal/core/services"
 	"github.com/theblitlabs/parity-server/internal/utils"
-	requestmodels "github.com/theblitlabs/parity-server/internal/api/models"
 )
 
 type TaskHandler struct {
-	service     *services.TaskService
-	s3Service   *services.S3Service
-	stakeWallet *walletsdk.StakeWallet
+	service        *services.TaskService
+	s3Service      *services.S3Service
+	stakeWallet    *walletsdk.StakeWallet
 	webhookService *services.WebhookService
 	webhooks       map[string]requestmodels.WebhookRegistration
 }
@@ -121,12 +121,16 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 			}
 
 			if req.Environment == nil {
+				config := map[string]interface{}{
+					"image": req.Image,
+				}
+				if len(req.Command) > 0 {
+					config["command"] = req.Command
+				}
+
 				req.Environment = &models.EnvironmentConfig{
-					Type: "docker",
-					Config: map[string]interface{}{
-						"image":   req.Image,
-						"command": req.Command,
-					},
+					Type:   "docker",
+					Config: config,
 				}
 			}
 
@@ -153,12 +157,16 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 		if req.Image != "" {
 			req.Type = models.TaskTypeDocker
 			if req.Environment == nil {
+				config := map[string]interface{}{
+					"image": req.Image,
+				}
+				if len(req.Command) > 0 {
+					config["command"] = req.Command
+				}
+
 				req.Environment = &models.EnvironmentConfig{
-					Type: "docker",
-					Config: map[string]interface{}{
-						"image":   req.Image,
-						"command": req.Command,
-					},
+					Type:   "docker",
+					Config: config,
 				}
 			}
 

--- a/internal/core/models/task.go
+++ b/internal/core/models/task.go
@@ -51,9 +51,6 @@ type ResourceConfig struct {
 func (c *TaskConfig) Validate(taskType TaskType) error {
 	switch taskType {
 	case TaskTypeDocker:
-		if len(c.Command) == 0 {
-			return errors.New("command is required for Docker tasks")
-		}
 		if c.ImageName == "" {
 			return errors.New("image name is required for Docker tasks")
 		}
@@ -61,9 +58,7 @@ func (c *TaskConfig) Validate(taskType TaskType) error {
 			return errors.New("either docker image URL or file URL is required for Docker tasks")
 		}
 	case TaskTypeCommand:
-		if len(c.Command) == 0 {
-			return errors.New("command is required for Command tasks")
-		}
+		// Command can be empty for both Docker and Command tasks
 	default:
 		return fmt.Errorf("unsupported task type: %s", taskType)
 	}


### PR DESCRIPTION
This PR makes the `command` parameter optional when creating tasks, both for Docker and Command task types. The validation logic and handler have been updated to allow tasks to be created without specifying a command. This improves flexibility for task creation and supports use cases where a command may not be necessary at creation time.

**Changes:**
- Updated `TaskConfig.Validate` to not require `command` for Docker or Command tasks.
- Updated `TaskHandler.CreateTask` to handle missing or empty `command` fields gracefully.
- Ensured backward compatibility for existing task creation flows.

Closes #31

