### PR TITLE
fix(task): use deviceID for stake validation

### DIFF
--- a/internal/api/handlers/task_handler.go
+++ b/internal/api/handlers/task_handler.go
@@ -13,16 +13,16 @@ import (
 	"github.com/google/uuid"
 	walletsdk "github.com/theblitlabs/go-wallet-sdk"
 	"github.com/theblitlabs/gologger"
+	requestmodels "github.com/theblitlabs/parity-server/internal/api/models"
 	"github.com/theblitlabs/parity-server/internal/core/models"
 	"github.com/theblitlabs/parity-server/internal/core/services"
 	"github.com/theblitlabs/parity-server/internal/utils"
-	requestmodels "github.com/theblitlabs/parity-server/internal/api/models"
 )
 
 type TaskHandler struct {
-	service     *services.TaskService
-	s3Service   *services.S3Service
-	stakeWallet *walletsdk.StakeWallet
+	service        *services.TaskService
+	s3Service      *services.S3Service
+	stakeWallet    *walletsdk.StakeWallet
 	webhookService *services.WebhookService
 	webhooks       map[string]requestmodels.WebhookRegistration
 }
@@ -39,7 +39,14 @@ func (h *TaskHandler) SetStakeWallet(wallet *walletsdk.StakeWallet) {
 	h.stakeWallet = wallet
 }
 
+func (h *TaskHandler) SetWebhookService(service *services.WebhookService) {
+	h.webhookService = service
+}
+
 func (h *TaskHandler) NotifyTaskUpdate() {
+	if h.webhookService == nil {
+		return
+	}
 	h.webhookService.NotifyTaskUpdate()
 }
 
@@ -307,21 +314,59 @@ func (h *TaskHandler) SaveTaskResult(c *gin.Context) {
 }
 
 func (h *TaskHandler) checkStakeBalance(task *models.Task) error {
+	log := gologger.WithComponent("task_handler")
+
 	if h.stakeWallet == nil {
+		log.Error().Str("creator_address", task.CreatorAddress).Msg("Stake wallet not initialized")
 		return fmt.Errorf("stake wallet not initialized")
 	}
 
 	info, err := h.stakeWallet.GetStakeInfo(task.CreatorAddress)
 	if err != nil {
+		log.Error().Err(err).Str("creator_address", task.CreatorAddress).Msg("Failed to get stake info")
 		return fmt.Errorf("failed to get stake info: %v", err)
 	}
 
+	log.Info().
+		Str("creator_address", task.CreatorAddress).
+		Bool("exists", info.Exists).
+		Str("amount", info.Amount.String()).
+		Msg("Retrieved stake info")
+
 	if !info.Exists {
+		log.Info().Str("creator_address", task.CreatorAddress).Msg("Wallet not registered, trying with device ID")
+
+		deviceInfo, deviceErr := h.stakeWallet.GetStakeInfo(task.CreatorDeviceID)
+		if deviceErr != nil {
+			log.Error().Err(deviceErr).Str("device_id", task.CreatorDeviceID).Msg("Failed to get stake info for device ID")
+		} else {
+			log.Info().
+				Str("device_id", task.CreatorDeviceID).
+				Bool("exists", deviceInfo.Exists).
+				Str("amount", deviceInfo.Amount.String()).
+				Msg("Retrieved stake info for device ID")
+
+			if deviceInfo.Exists && deviceInfo.Amount.Cmp(big.NewInt(0)) > 0 {
+				info = deviceInfo
+			}
+		}
+	}
+
+	if !info.Exists {
+		log.Error().
+			Str("creator_address", task.CreatorAddress).
+			Str("device_id", task.CreatorDeviceID).
+			Msg("Neither wallet address nor device ID are registered in staking contract")
 		return fmt.Errorf("wallet %s is not registered in the staking contract - please stake PRTY tokens first", task.CreatorAddress)
 	}
 
 	minRequiredStake := big.NewInt(10)
 	if info.Amount.Cmp(minRequiredStake) <= 0 {
+		log.Error().
+			Str("creator_address", task.CreatorAddress).
+			Str("current_balance", info.Amount.String()).
+			Str("required_balance", minRequiredStake.String()).
+			Msg("Insufficient stake balance")
 		return fmt.Errorf("insufficient stake balance for wallet %s - current balance: %v PRTY, minimum required: %v PRTY",
 			task.CreatorAddress,
 			info.Amount.String(),

--- a/internal/api/handlers/task_handler.go
+++ b/internal/api/handlers/task_handler.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"math/big"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -317,13 +316,6 @@ func (h *TaskHandler) checkStakeBalance(task *models.Task) error {
 		return fmt.Errorf("stake wallet not initialized")
 	}
 
-	// Check if we're in development mode and bypass stake check
-	if os.Getenv("PARITY_ENV") == "development" && os.Getenv("BYPASS_STAKE_CHECK") == "true" {
-		log.Info().Str("device_id", task.CreatorDeviceID).Msg("Bypassing stake check in development mode")
-		return nil
-	}
-
-	// Only check stake for device ID, not wallet address
 	info, err := h.stakeWallet.GetStakeInfo(task.CreatorDeviceID)
 	if err != nil {
 		log.Error().Err(err).Str("device_id", task.CreatorDeviceID).Msg("Failed to get stake info")

--- a/internal/api/handlers/task_handler.go
+++ b/internal/api/handlers/task_handler.go
@@ -196,9 +196,7 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 		return
 	}
 
-	// Creator address is now optional since we only check device ID for stake
-	creatorAddress := c.GetHeader("X-Creator-Address")
-	// We still store the creator address for reference, but don't require it
+	creatorAddress := c.GetHeader("X-Creator-Address") // We store the creator address for reference, but don't require it now
 
 	if req.Type != models.TaskTypeDocker && req.Type != models.TaskTypeCommand {
 		log.Error().Str("type", string(req.Type)).Msg("Invalid task type")

--- a/internal/core/app/server_builder.go
+++ b/internal/core/app/server_builder.go
@@ -304,6 +304,7 @@ func (sb *ServerBuilder) InitRouter() *ServerBuilder {
 
 	sb.taskHandler = handlers.NewTaskHandler(sb.taskService, sb.s3Service)
 	sb.taskHandler.SetStakeWallet(sb.stakeWallet)
+	sb.taskHandler.SetWebhookService(sb.webhookService)
 
 	sb.runnerHandler = handlers.NewRunnerHandler(sb.taskService, sb.runnerService)
 	sb.webhookHandler = handlers.NewWebhookHandler(sb.webhookService, sb.runnerService)


### PR DESCRIPTION
This PR refactors the task creation stake validation to only use the device ID, not the wallet address. This aligns with how tokens are currently being staked in the system.

### Changes:
1. Modified stake validation to check only the device ID for PRTY token stake
2. Made the `X-Creator-Address` header optional in API requests
3. Updated error messages to reference device ID instead of wallet address
4. Added detailed logging to help diagnose stake validation issues
5. Fixed nil pointer dereference in webhook notification system

### Technical Details:
- Previously, the system would check the creator's wallet address for stake, but fail even if tokens were staked against the device ID
- Now, stake validation only checks the device ID, which matches how users are actually staking tokens