### PR TITLE
refactor: remove Command parameter

### DIFF
--- a/internal/api/handlers/runner_handler.go
+++ b/internal/api/handlers/runner_handler.go
@@ -241,4 +241,4 @@ func (h *RunnerHandler) NotifyRunnerOfTasks(runnerID string, tasks []*coremodels
 		Int("num_tasks", len(tasks)).
 		Msg("Successfully notified runner of tasks")
 	return nil
-} 
+}

--- a/internal/api/handlers/task_handler.go
+++ b/internal/api/handlers/task_handler.go
@@ -131,9 +131,6 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 				config := map[string]interface{}{
 					"image": req.Image,
 				}
-				if len(req.Command) > 0 {
-					config["command"] = req.Command
-				}
 
 				req.Environment = &models.EnvironmentConfig{
 					Type:   "docker",
@@ -142,7 +139,6 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 			}
 
 			taskConfig := models.TaskConfig{
-				Command:        req.Command,
 				DockerImageURL: imageURL,
 				ImageName:      strings.TrimSuffix(file.Filename, ".tar"),
 			}
@@ -167,9 +163,6 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 				config := map[string]interface{}{
 					"image": req.Image,
 				}
-				if len(req.Command) > 0 {
-					config["command"] = req.Command
-				}
 
 				req.Environment = &models.EnvironmentConfig{
 					Type:   "docker",
@@ -178,7 +171,6 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 			}
 
 			taskConfig := models.TaskConfig{
-				Command:   req.Command,
 				ImageName: req.Image,
 			}
 
@@ -227,10 +219,6 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 		if taskConfig.ImageName == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Image name is required for Docker tasks"})
 			return
-		}
-
-		if len(taskConfig.Command) == 0 {
-			taskConfig.Command = []string{}
 		}
 	}
 

--- a/internal/api/handlers/webhook_handler.go
+++ b/internal/api/handlers/webhook_handler.go
@@ -95,4 +95,4 @@ func (h *WebhookHandler) UnregisterWebhook(c *gin.Context) {
 
 func (h *WebhookHandler) CleanupResources() {
 	h.webhookService.CleanupResources()
-} 
+}

--- a/internal/api/models/requests.go
+++ b/internal/api/models/requests.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"time"
+
 	coremodels "github.com/theblitlabs/parity-server/internal/core/models"
 )
 
@@ -24,23 +25,22 @@ type WSMessage struct {
 }
 
 type CreateTaskRequest struct {
-	Title       string                         `json:"title"`
-	Description string                         `json:"description"`
+	Title       string                        `json:"title"`
+	Description string                        `json:"description"`
 	Type        coremodels.TaskType           `json:"type"`
-	Image       string                         `json:"image"`
-	Command     []string                       `json:"command"`
+	Image       string                        `json:"image"`
 	Config      json.RawMessage               `json:"config"`
 	Environment *coremodels.EnvironmentConfig `json:"environment,omitempty"`
 	Reward      float64                       `json:"reward"`
 	CreatorID   string                        `json:"creator_id"`
-} 
+}
 
 type HeartbeatPayload struct {
-	WalletAddress string              `json:"wallet_address"`
+	WalletAddress string                  `json:"wallet_address"`
 	Status        coremodels.RunnerStatus `json:"status"`
-	Timestamp     int64               `json:"timestamp"`
-	Uptime        int64               `json:"uptime"`
-	Memory        int64               `json:"memory_usage"`
-	CPU           float64             `json:"cpu_usage"`
-	PublicIP      string              `json:"public_ip,omitempty"`
+	Timestamp     int64                   `json:"timestamp"`
+	Uptime        int64                   `json:"uptime"`
+	Memory        int64                   `json:"memory_usage"`
+	CPU           float64                 `json:"cpu_usage"`
+	PublicIP      string                  `json:"public_ip,omitempty"`
 }

--- a/internal/api/v1/routes.go
+++ b/internal/api/v1/routes.go
@@ -8,32 +8,32 @@ import (
 func registerTaskRoutes(router *gin.RouterGroup, taskHandler *handlers.TaskHandler) {
 	tasks := router.Group("/tasks")
 	{
-		tasks.POST("", taskHandler.CreateTask)        
-		tasks.GET("", taskHandler.ListTasks)        
+		tasks.POST("", taskHandler.CreateTask)
+		tasks.GET("", taskHandler.ListTasks)
 		tasks.GET("/:id", taskHandler.GetTask)
-		tasks.GET("/:id/reward", taskHandler.GetTaskReward)  
-		tasks.GET("/:id/result", taskHandler.GetTaskResult)  
+		tasks.GET("/:id/reward", taskHandler.GetTaskReward)
+		tasks.GET("/:id/result", taskHandler.GetTaskResult)
 	}
 }
 
 func registerRunnerRoutes(router *gin.RouterGroup, taskHandler *handlers.TaskHandler, runnerHandler *handlers.RunnerHandler, webhookHandler *handlers.WebhookHandler) {
 	runners := router.Group("/runners")
 	{
-		runners.POST("", runnerHandler.RegisterRunner)          
-		runners.POST("/heartbeat", runnerHandler.RunnerHeartbeat) 
-		
+		runners.POST("", runnerHandler.RegisterRunner)
+		runners.POST("/heartbeat", runnerHandler.RunnerHeartbeat)
+
 		runnerTasks := runners.Group("/tasks")
 		{
-			runnerTasks.GET("/available", runnerHandler.ListAvailableTasks)  
-			runnerTasks.POST("/:id/start", runnerHandler.StartTask)         
-			runnerTasks.POST("/:id/complete", runnerHandler.CompleteTask)   
-			runnerTasks.POST("/:id/result", taskHandler.SaveTaskResult)   
+			runnerTasks.GET("/available", runnerHandler.ListAvailableTasks)
+			runnerTasks.POST("/:id/start", runnerHandler.StartTask)
+			runnerTasks.POST("/:id/complete", runnerHandler.CompleteTask)
+			runnerTasks.POST("/:id/result", taskHandler.SaveTaskResult)
 		}
-		
+
 		runnerWebhooks := runners.Group("/webhooks")
 		{
-			runnerWebhooks.POST("", webhookHandler.RegisterWebhook)      
-			runnerWebhooks.DELETE("", webhookHandler.UnregisterWebhook)  
+			runnerWebhooks.POST("", webhookHandler.RegisterWebhook)
+			runnerWebhooks.DELETE("", webhookHandler.UnregisterWebhook)
 		}
 	}
 }
@@ -41,4 +41,4 @@ func registerRunnerRoutes(router *gin.RouterGroup, taskHandler *handlers.TaskHan
 func RegisterRoutes(api *gin.RouterGroup, taskHandler *handlers.TaskHandler, runnerHandler *handlers.RunnerHandler, webhookHandler *handlers.WebhookHandler) {
 	registerTaskRoutes(api, taskHandler)
 	registerRunnerRoutes(api, taskHandler, runnerHandler, webhookHandler)
-} 
+}

--- a/internal/core/models/task.go
+++ b/internal/core/models/task.go
@@ -35,7 +35,6 @@ type DockerConfig struct {
 
 type TaskConfig struct {
 	FileURL        string            `json:"file_url,omitempty"`
-	Command        []string          `json:"command,omitempty"`
 	Env            map[string]string `json:"env,omitempty"`
 	Resources      ResourceConfig    `json:"resources,omitempty"`
 	DockerImageURL string            `json:"docker_image_url,omitempty"`


### PR DESCRIPTION
This PR removes the "command" parameter from the task model to simplify the API and internal task representation.

### Changes
- Removed the `Command` field from the `TaskConfig` struct in task.go
- Removed the `Command` field from the `CreateTaskRequest` struct in requests.go
- Updated the task_handler.go file to remove all references to the command parameter

### Related
- https://github.com/theblitlabs/parity-runner/pull/43
