### PR TITLE
feat: Server-side Hash Verification and Consensus Layer

### DIFF
--- a/internal/api/v1/routes.go
+++ b/internal/api/v1/routes.go
@@ -13,6 +13,7 @@ func registerTaskRoutes(router *gin.RouterGroup, taskHandler *handlers.TaskHandl
 		tasks.GET("/:id", taskHandler.GetTask)
 		tasks.GET("/:id/reward", taskHandler.GetTaskReward)
 		tasks.GET("/:id/result", taskHandler.GetTaskResult)
+		tasks.POST("/:id/verify-hashes", taskHandler.VerifyTaskHashes)
 	}
 }
 

--- a/internal/core/app/server_builder.go
+++ b/internal/core/app/server_builder.go
@@ -113,26 +113,27 @@ func (s *Server) Shutdown(ctx context.Context) {
 }
 
 type ServerBuilder struct {
-	config           *config.Config
-	dbManager        *db.DBManager
-	repoFactory      *db.RepositoryFactory
-	taskRepo         *repositories.TaskRepository
-	runnerRepo       *repositories.RunnerRepository
-	taskService      *services.TaskService
-	runnerService    *services.RunnerService
-	heartbeatService *services.HeartbeatService
-	webhookService   *services.WebhookService
-	s3Service        *services.S3Service
-	stakeWallet      *walletsdk.StakeWallet
-	taskHandler      *handlers.TaskHandler
-	runnerHandler    *handlers.RunnerHandler
-	webhookHandler   *handlers.WebhookHandler
-	httpServer       *http.Server
-	stopChannel      chan struct{}
-	monitorCtx       context.Context
-	monitorCancel    context.CancelFunc
-	monitorWg        *sync.WaitGroup
-	err              error
+	config              *config.Config
+	dbManager           *db.DBManager
+	repoFactory         *db.RepositoryFactory
+	taskRepo            *repositories.TaskRepository
+	runnerRepo          *repositories.RunnerRepository
+	taskService         *services.TaskService
+	runnerService       *services.RunnerService
+	heartbeatService    *services.HeartbeatService
+	webhookService      *services.WebhookService
+	s3Service           *services.S3Service
+	verificationService *services.VerificationService
+	stakeWallet         *walletsdk.StakeWallet
+	taskHandler         *handlers.TaskHandler
+	runnerHandler       *handlers.RunnerHandler
+	webhookHandler      *handlers.WebhookHandler
+	httpServer          *http.Server
+	stopChannel         chan struct{}
+	monitorCtx          context.Context
+	monitorCancel       context.CancelFunc
+	monitorWg           *sync.WaitGroup
+	err                 error
 }
 
 func NewServerBuilder(cfg *config.Config) *ServerBuilder {
@@ -200,6 +201,8 @@ func (sb *ServerBuilder) InitServices() *ServerBuilder {
 		return sb
 	}
 	sb.s3Service = s3Service
+
+	sb.verificationService = services.NewVerificationService(sb.taskRepo)
 
 	return sb
 }
@@ -302,7 +305,7 @@ func (sb *ServerBuilder) InitRouter() *ServerBuilder {
 		return sb
 	}
 
-	sb.taskHandler = handlers.NewTaskHandler(sb.taskService, sb.s3Service)
+	sb.taskHandler = handlers.NewTaskHandler(sb.taskService, sb.s3Service, sb.verificationService)
 	sb.taskHandler.SetStakeWallet(sb.stakeWallet)
 	sb.taskHandler.SetWebhookService(sb.webhookService)
 

--- a/internal/core/models/task.go
+++ b/internal/core/models/task.go
@@ -76,6 +76,8 @@ type Task struct {
 	CreatorDeviceID string             `json:"creator_device_id" gorm:"type:varchar(255)"`
 	RunnerID        string             `json:"runner_id" gorm:"type:varchar(255)"`
 	Nonce           string             `json:"nonce" gorm:"type:varchar(64);not null"`
+	ImageHash       string             `json:"image_hash" gorm:"type:varchar(64)"`
+	CommandHash     string             `json:"command_hash" gorm:"type:varchar(64)"`
 	CreatedAt       time.Time          `json:"created_at" gorm:"type:timestamp"`
 	UpdatedAt       time.Time          `json:"updated_at" gorm:"type:timestamp"`
 	CompletedAt     *time.Time         `json:"completed_at" gorm:"type:timestamp"`

--- a/internal/core/models/task_result.go
+++ b/internal/core/models/task_result.go
@@ -10,25 +10,29 @@ import (
 )
 
 type TaskResult struct {
-	ID              uuid.UUID `json:"id" gorm:"type:uuid;primaryKey"`
-	TaskID          uuid.UUID `json:"task_id" gorm:"type:uuid;index;not null;constraint:fk_task,onDelete:CASCADE"`
-	DeviceID        string    `json:"device_id" gorm:"type:varchar(255);not null"`
-	DeviceIDHash    string    `json:"device_id_hash" gorm:"type:varchar(64);not null"`
-	RunnerAddress   string    `json:"runner_address" gorm:"type:varchar(255);not null"`
-	CreatorAddress  string    `json:"creator_address" gorm:"type:varchar(255);not null"`
-	Output          string    `json:"output" gorm:"type:text"`
-	Error           string    `json:"error,omitempty" gorm:"type:text"`
-	ExitCode        int       `json:"exit_code" gorm:"type:int"`
-	ExecutionTime   int64     `json:"execution_time" gorm:"type:bigint"`
-	CreatedAt       time.Time `json:"created_at" gorm:"type:timestamp with time zone;default:now()"`
-	CreatorDeviceID string    `json:"creator_device_id" gorm:"type:text"`
-	SolverDeviceID  string    `json:"solver_device_id" gorm:"type:text"`
-	Reward          float64   `json:"reward" gorm:"type:decimal(20,8)"`
-	CPUSeconds      float64   `json:"cpu_seconds" gorm:"type:decimal(20,8);default:0"`
-	EstimatedCycles uint64    `json:"estimated_cycles" gorm:"type:bigint;not null;default:0"`
-	MemoryGBHours   float64   `json:"memory_gb_hours" gorm:"type:decimal(20,8);default:0"`
-	StorageGB       float64   `json:"storage_gb" gorm:"type:decimal(20,8);default:0"`
-	NetworkDataGB   float64   `json:"network_data_gb" gorm:"type:decimal(20,8);default:0"`
+	ID                  uuid.UUID `json:"id" gorm:"type:uuid;primaryKey"`
+	TaskID              uuid.UUID `json:"task_id" gorm:"type:uuid;index;not null;constraint:fk_task,onDelete:CASCADE"`
+	DeviceID            string    `json:"device_id" gorm:"type:varchar(255);not null"`
+	DeviceIDHash        string    `json:"device_id_hash" gorm:"type:varchar(64);not null"`
+	RunnerAddress       string    `json:"runner_address" gorm:"type:varchar(255);not null"`
+	CreatorAddress      string    `json:"creator_address" gorm:"type:varchar(255);not null"`
+	Output              string    `json:"output" gorm:"type:text"`
+	Error               string    `json:"error,omitempty" gorm:"type:text"`
+	ExitCode            int       `json:"exit_code" gorm:"type:int"`
+	ExecutionTime       int64     `json:"execution_time" gorm:"type:bigint"`
+	ResultHash          string    `json:"result_hash" gorm:"type:varchar(64)"`
+	ImageHashVerified   string    `json:"image_hash_verified" gorm:"type:varchar(64)"`
+	CommandHashVerified string    `json:"command_hash_verified" gorm:"type:varchar(64)"`
+	VerificationStatus  string    `json:"verification_status" gorm:"type:varchar(50);default:'pending'"`
+	CreatedAt           time.Time `json:"created_at" gorm:"type:timestamp with time zone;default:now()"`
+	CreatorDeviceID     string    `json:"creator_device_id" gorm:"type:text"`
+	SolverDeviceID      string    `json:"solver_device_id" gorm:"type:text"`
+	Reward              float64   `json:"reward" gorm:"type:decimal(20,8)"`
+	CPUSeconds          float64   `json:"cpu_seconds" gorm:"type:decimal(20,8);default:0"`
+	EstimatedCycles     uint64    `json:"estimated_cycles" gorm:"type:bigint;not null;default:0"`
+	MemoryGBHours       float64   `json:"memory_gb_hours" gorm:"type:decimal(20,8);default:0"`
+	StorageGB           float64   `json:"storage_gb" gorm:"type:decimal(20,8);default:0"`
+	NetworkDataGB       float64   `json:"network_data_gb" gorm:"type:decimal(20,8);default:0"`
 }
 
 func (r *TaskResult) Clean() {

--- a/internal/core/services/consensus.go
+++ b/internal/core/services/consensus.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/theblitlabs/gologger"
+	"github.com/theblitlabs/parity-server/internal/core/models"
+	"github.com/theblitlabs/parity-server/internal/utils"
+)
+
+type ConsensusService struct {
+	taskRepo            TaskRepository
+	verificationService *VerificationService
+}
+
+func NewConsensusService(taskRepo TaskRepository, verificationService *VerificationService) *ConsensusService {
+	return &ConsensusService{
+		taskRepo:            taskRepo,
+		verificationService: verificationService,
+	}
+}
+
+func (s *ConsensusService) ProcessTaskConsensus(ctx context.Context, taskID string, results []*models.TaskResult) (*models.TaskResult, error) {
+	log := gologger.WithComponent("consensus")
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no results provided for consensus")
+	}
+
+	log.Info().
+		Str("task_id", taskID).
+		Int("result_count", len(results)).
+		Msg("Processing task consensus")
+
+	consensusResult, err := s.verificationService.ProcessTaskResults(ctx, taskID, results)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("task_id", taskID).
+			Msg("Failed to process task results consensus")
+		return nil, err
+	}
+
+	if consensusResult == nil {
+		log.Warn().
+			Str("task_id", taskID).
+			Msg("No consensus reached for task")
+		return nil, fmt.Errorf("no consensus reached for task %s", taskID)
+	}
+
+	log.Info().
+		Str("task_id", taskID).
+		Str("consensus_result_id", consensusResult.ID.String()).
+		Str("result_hash", consensusResult.ResultHash).
+		Msg("Consensus reached for task")
+
+	return consensusResult, nil
+}
+
+func (s *ConsensusService) ValidateResultIntegrity(result *models.TaskResult) error {
+	log := gologger.WithComponent("consensus")
+
+	if result.ResultHash == "" {
+		return fmt.Errorf("result hash is missing")
+	}
+
+	expectedHash := utils.ComputeResultHash(result.Output, result.Error, result.ExitCode)
+	if result.ResultHash != expectedHash {
+		log.Error().
+			Str("result_id", result.ID.String()).
+			Str("expected_hash", expectedHash).
+			Str("actual_hash", result.ResultHash).
+			Msg("Result hash mismatch detected")
+		return fmt.Errorf("result hash mismatch: expected %s, got %s", expectedHash, result.ResultHash)
+	}
+
+	log.Debug().
+		Str("result_id", result.ID.String()).
+		Str("result_hash", result.ResultHash).
+		Msg("Result integrity validated")
+
+	return nil
+}
+
+func (s *ConsensusService) CheckMinimumRunners(results []*models.TaskResult, minRunners int) error {
+	if len(results) < minRunners {
+		return fmt.Errorf("insufficient runners: got %d, minimum required %d", len(results), minRunners)
+	}
+	return nil
+}

--- a/internal/core/services/verification.go
+++ b/internal/core/services/verification.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/theblitlabs/gologger"
+	"github.com/theblitlabs/parity-server/internal/core/models"
+	"github.com/theblitlabs/parity-server/internal/utils"
+)
+
+type VerificationService struct {
+	taskRepo TaskRepository
+}
+
+func NewVerificationService(taskRepo TaskRepository) *VerificationService {
+	return &VerificationService{
+		taskRepo: taskRepo,
+	}
+}
+
+func (s *VerificationService) VerifyTaskExecution(ctx context.Context, taskID string, imageHashVerified, commandHashVerified string) error {
+	taskUUID, err := uuid.Parse(taskID)
+	if err != nil {
+		return fmt.Errorf("invalid task ID: %w", err)
+	}
+
+	task, err := s.taskRepo.Get(ctx, taskUUID)
+	if err != nil {
+		return fmt.Errorf("failed to get task: %w", err)
+	}
+
+	if !utils.VerifyTaskHashes(task, imageHashVerified, commandHashVerified) {
+		log.Error().
+			Str("task_id", taskID).
+			Str("expected_image_hash", task.ImageHash).
+			Str("verified_image_hash", imageHashVerified).
+			Str("expected_command_hash", task.CommandHash).
+			Str("verified_command_hash", commandHashVerified).
+			Msg("Hash verification failed")
+		return fmt.Errorf("hash verification failed for task %s", taskID)
+	}
+
+	log.Info().
+		Str("task_id", taskID).
+		Msg("Hash verification successful")
+	return nil
+}
+
+func (s *VerificationService) ProcessTaskResults(ctx context.Context, taskID string, results []*models.TaskResult) (*models.TaskResult, error) {
+	log := gologger.WithComponent("verification")
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no results found for task %s", taskID)
+	}
+
+	consensusHash, hasConsensus := utils.CheckConsensus(results, 0.67)
+	if !hasConsensus {
+		log.Warn().
+			Str("task_id", taskID).
+			Int("result_count", len(results)).
+			Msg("No consensus reached for task results")
+
+		for _, result := range results {
+			result.VerificationStatus = "failed_consensus"
+		}
+		return nil, fmt.Errorf("no consensus reached for task %s", taskID)
+	}
+
+	var consensusResult *models.TaskResult
+	for _, result := range results {
+		if result.ResultHash == consensusHash {
+			result.VerificationStatus = "verified"
+			consensusResult = result
+		} else {
+			result.VerificationStatus = "rejected"
+		}
+	}
+
+	log.Info().
+		Str("task_id", taskID).
+		Str("consensus_hash", consensusHash).
+		Int("total_results", len(results)).
+		Msg("Consensus reached for task results")
+
+	return consensusResult, nil
+}

--- a/internal/utils/hash.go
+++ b/internal/utils/hash.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+
+	"github.com/theblitlabs/parity-server/internal/core/models"
+)
+
+func ComputeCommandHash(command []string) string {
+	commandStr := strings.Join(command, " ")
+	hash := sha256.Sum256([]byte(commandStr))
+	return fmt.Sprintf("%x", hash)
+}
+
+func ComputeResultHash(stdout, stderr string, exitCode int) string {
+	combined := fmt.Sprintf("%s%s%d", stdout, stderr, exitCode)
+	hash := sha256.Sum256([]byte(combined))
+	return fmt.Sprintf("%x", hash)
+}
+
+func VerifyTaskHashes(task *models.Task, imageHashVerified, commandHashVerified string) bool {
+	if task.ImageHash != "" && task.ImageHash != imageHashVerified {
+		return false
+	}
+	if task.CommandHash != "" && task.CommandHash != commandHashVerified {
+		return false
+	}
+	return true
+}
+
+func CheckConsensus(results []*models.TaskResult, threshold float64) (string, bool) {
+	if len(results) == 0 {
+		return "", false
+	}
+
+	hashCounts := make(map[string]int)
+	for _, result := range results {
+		if result.ResultHash != "" {
+			hashCounts[result.ResultHash]++
+		}
+	}
+
+	totalResults := len(results)
+	requiredCount := int(float64(totalResults) * threshold)
+
+	for hash, count := range hashCounts {
+		if count >= requiredCount {
+			return hash, true
+		}
+	}
+
+	return "", false
+}


### PR DESCRIPTION
# Implements server-side hash verification and multi-runner consensus for the Parity Protocol.

## Changes
- Add hash verification utilities and services
- Extend task and result models to support hash verification
- Add verification endpoint for runner hash validation
- Implement multi-runner consensus mechanism with ⅔ majority rule
- Add consensus service for result integrity validation
- Integrate verification service into task handler and routing

## Related PRs
- **Client-side implementation**: https://github.com/theblitlabs/parity-client/pull/14
- **Runner-side implementation**: https://github.com/theblitlabs/parity-runner/pull/44
## Closes
- https://github.com/theblitlabs/parity-runner/issues/29

## Testing
- [x] Pre-commit checks pass
- [x] Verification services tested
- [x] Consensus logic validated